### PR TITLE
add "install from release" test

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -71,11 +71,11 @@ teardown() {
   grep -q 'Custom Laravel Gitpod' "${TESTDIR}/.gitpod.yml"
 }
 
-# @test "install from release" {
-#   set -eu -o pipefail
-#   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-#   echo "# ddev get ddev/ddev-addon-template with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-#   ddev get ddev/ddev-addon-template
-#   ddev restart >/dev/null
-#   health_checks
-# }
+@test "install from release" {
+  set -eu -o pipefail
+  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+  echo "# ddev get tyler36/ddev-gitpod-setup with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get tyler36/ddev-gitpod-setup
+  ddev restart >/dev/null
+  health_checks
+}


### PR DESCRIPTION
This PR enables the "install from release" test.

This requires an initial release which has now been done (`v0.1`).