### PR TITLE
add Drupal project-type

### DIFF
--- a/gitpod-setup/drupal.yml
+++ b/gitpod-setup/drupal.yml
@@ -1,0 +1,11 @@
+## -------------------------
+## Define how Gitpod prepares and builds your project and how it can start the project’s development server(s).
+## @see https://www.gitpod.io/docs/references/gitpod-yml#tasks
+tasks:
+  - init: |
+      ddev start -y
+      ddev composer install
+      ddev drush si -y --account-pass=admin --site-name='ddev_gitpod'
+    command: |
+      ddev start -y
+      gp ports await 8080 && gp preview $(gp url 8080)

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -79,3 +79,14 @@ teardown() {
   ddev restart >/dev/null
   health_checks
 }
+
+@test "it configures gitpod for Drupal" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev config --project-type=drupal
+  ddev get ${DIR}
+
+  health_checks
+  grep -q 'ddev drush si -y' "${TESTDIR}/.gitpod.yml"
+}


### PR DESCRIPTION
This PR adds a simple `drupal` project-type gitpod task list.

This supports the recent `drupal` project-type and will not work for version specific project types (Eg. `drupal-7`, `drupal-10`). 

The tasks _in theory_ are compatible with modern Drupal as it assumes:

- its a composer based project
- `drush` is available