### PR TITLE
fix: Update DDEV to current stable on startup

### DIFF
--- a/gitpod-setup/.gitpod.yml
+++ b/gitpod-setup/.gitpod.yml
@@ -1,6 +1,6 @@
 
 ##ddev-generated
-image: ddev/ddev-gitpod-base:20240702
+image: ddev/ddev-gitpod-base:20240923
 
 ## -------------------------
 ## Configure the VS Code editor.

--- a/gitpod-setup/drupal.yml
+++ b/gitpod-setup/drupal.yml
@@ -1,3 +1,4 @@
+#ddev-generated
 ## -------------------------
 ## Define how Gitpod prepares and builds your project and how it can start the project’s development server(s).
 ## @see https://www.gitpod.io/docs/references/gitpod-yml#tasks

--- a/gitpod-setup/drupal.yml
+++ b/gitpod-setup/drupal.yml
@@ -3,6 +3,8 @@
 ## @see https://www.gitpod.io/docs/references/gitpod-yml#tasks
 tasks:
   - init: |
+      # Upgrade DDEV to current stable version
+      sudo apt update >/dev/null 2>&1 && sudo apt -qq -y install ddev
       ddev start -y
       ddev composer install
       ddev drush si -y --account-pass=admin --site-name='ddev_gitpod'

--- a/gitpod-setup/drupal.yml
+++ b/gitpod-setup/drupal.yml
@@ -10,5 +10,7 @@ tasks:
       ddev composer install
       ddev drush si -y --account-pass=admin --site-name='ddev_gitpod'
     command: |
+      # Upgrade DDEV to current stable version
+      sudo apt update >/dev/null 2>&1 && sudo apt -qq -y install ddev
       ddev start -y
       gp ports await 8080 && gp preview $(gp url 8080)

--- a/gitpod-setup/laravel.yml
+++ b/gitpod-setup/laravel.yml
@@ -4,6 +4,8 @@
 ## @see https://www.gitpod.io/docs/references/gitpod-yml#tasks
 tasks:
   - init: |
+      # Upgrade DDEV to current stable version
+      sudo apt update >/dev/null 2>&1 && sudo apt -qq -y install ddev
       ddev start -y
       ddev composer install
       ddev npm install

--- a/gitpod-setup/laravel.yml
+++ b/gitpod-setup/laravel.yml
@@ -11,5 +11,7 @@ tasks:
       ddev npm install
       ddev artisan key:generate
     command: |
+      # Upgrade DDEV to current stable version
+      sudo apt update >/dev/null 2>&1 && sudo apt -qq -y install ddev
       ddev start -y
       gp ports await 8080 && gp preview $(gp url 8080)

--- a/gitpod-setup/php.yml
+++ b/gitpod-setup/php.yml
@@ -4,6 +4,8 @@
 ## @see https://www.gitpod.io/docs/references/gitpod-yml#tasks
 tasks:
   - init: |
+      # Upgrade DDEV to current stable version
+      sudo apt update >/dev/null 2>&1 && sudo apt -qq -y install ddev
       ddev start -y
       ddev composer install
     command: |

--- a/gitpod-setup/php.yml
+++ b/gitpod-setup/php.yml
@@ -9,5 +9,7 @@ tasks:
       ddev start -y
       ddev composer install
     command: |
+      # Upgrade DDEV to current stable version
+      sudo apt update >/dev/null 2>&1 && sudo apt -qq -y install ddev
       ddev start -y
       gp ports await 8080 && gp preview $(gp url 8080)

--- a/install.yaml
+++ b/install.yaml
@@ -1,4 +1,4 @@
-name: ddev-gitpod-setup
+name: gitpod-setup
 
 project_files:
   - gitpod-setup/


### PR DESCRIPTION
Currently this may come up without having the current stable version of DDEV. This PR does an `apt install -y ddev` to get it to current. This wasn't predictable enough in gitpod so we'll revert to doing a new push of the base image for each release (and get that automated I guess)

Test with 

```
ddev get https://github.com/rfay/ddev-gitpod-setup/tarball/20240923_apt_upgrade
```

Other details:
* The drupal.yml didn't have #ddev-generated so couldn't be updated by the add-on
* The name in install.yaml was `ddev-gitpod-setup` could be better as `gitpod-setup` and easier to use. Hope that's OK.