### PR TITLE
Remove detailed debugging steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,43 +77,6 @@ We all have our preferred setup environment and "essential" extensions and add-o
 
 ### How to debug tests (Github Actions)
 
-1. You need an SSH-key registered with GitHub. You either pick the key you have already used with `github.com` or you create a dedicated new one with `ssh-keygen -t ed25519 -a 64 -f tmate_ed25519 -C "$(date +'%d-%m-%Y')"` and add it at `https://github.com/settings/keys`.
-
-2. Add the following snippet to `~/.ssh/config`:
-
-```config
-Host *.tmate.io
-    User git
-    AddKeysToAgent yes
-    UseKeychain yes
-    PreferredAuthentications publickey
-    IdentitiesOnly yes
-    IdentityFile ~/.ssh/tmate_ed25519
-```
-
-3. Go to `https://github.com/<user>/<repo>/actions/workflows/tests.yml`.
-
-4. Click the `Run workflow` button and you will have the option to select the branch to run the workflow from and activate `tmate` by checking the `Debug with tmate` checkbox for this run.
-
-![tmate](images/gh-tmate.jpg)
-
-5. After the `workflow_dispatch` event was triggered, click the `All workflows` link in the sidebar and then click the `tests` action in progress workflow.
-
-7. Pick one of the jobs in progress in the sidebar.
-
-8. Wait until the current task list reaches the `tmate debugging session` section and the output shows something like:
-
-```
-106 SSH: ssh PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
-107 or: ssh -i <path-to-private-SSH-key> PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
-108 SSH: ssh PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
-109 or: ssh -i <path-to-private-SSH-key> PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io
-```
-
-9. Copy and execute the first option `ssh PRbaS7SLVxbXImhjUqydQBgDL@nyc1.tmate.io` in the terminal and continue by pressing either <kbd>q</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd>.
-
-10. Start the Bats test with `bats ./tests/test.bats`.
-
-For a more detailed documentation about `tmate` see [Debug your GitHub Actions by using tmate](https://mxschmitt.github.io/action-tmate/).
+Please refer to the official [DDEV-addon-template README](https://github.com/ddev/ddev-addon-template?tab=readme-ov-file#how-to-debug-tests-github-actions) for a detailed guide.
 
 **Contributed and maintained by [@tyler36](https://github.com/tyler36)**


### PR DESCRIPTION
This PR removes the debugging section contents, and instead, redirects developers to DDEV-addon-template instead.

This declutterrs README and centralizes the single-source-of-truth for debugging.

Initially raised in #4.