### PR TITLE
Use latest tag for Gitpod

### DIFF
--- a/gitpod-setup/.gitpod.yml
+++ b/gitpod-setup/.gitpod.yml
@@ -1,6 +1,6 @@
 
 ##ddev-generated
-image: ddev/ddev-gitpod-base:20240923
+image: ddev/ddev-gitpod-base:latest
 
 ## -------------------------
 ## Configure the VS Code editor.


### PR DESCRIPTION
This PR defaults DDEV to "latest" tagged version. 
This should allow the addon to always use the latest release version and we no longer need to manually update it.

Fixes #10

