### PR TITLE
Update installation command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It does this by generating a `.gitpod.yml` file which includes:
 1. Install add-on
 
     ```shell
-    ddev get tyler36/ddev-gitpod-setup
+    ddev addon get tyler36/ddev-gitpod-setup
     ```
 
 2. Commit files to repository. All that really matters is the .gitpod.yml, but it does no harm to commit all the files the add-on creates.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It does this by generating a `.gitpod.yml` file which includes:
 - generic framework-specific tasks
 - DDEV base image
 - DDEV port settings
-- VSCode extensions
+- VS Code extensions
 - GitHub preferences
 
 @see [Gitpod documentation](https://www.gitpod.io/docs/references/gitpod-yml) for options settings. Most people don't need to change anything after just getting this setup.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It does this by generating a `.gitpod.yml` file which includes:
 
 ### Full control
 
-You can take over the `.gitpod.yml` and change it as you see fit, but most people don't need to do that. 
+You can take over the `.gitpod.yml` and change it as you see fit, but most people don't need to do that.
 
 - Remove `#ddev-generated` from `.gitpod.yml`. (This add-on will no longer manage the file.)
 - Make changes, as require.


### PR DESCRIPTION
This PR updates the installation command for the addon.

From DDEV `v1.23.5` 

- `ddev get` is deprecated
- `ddev addon` is the new command namespace.

This PR also includes a couple of minor opinionatred linting commits 