### PR TITLE
fix: run laravel migrations

### DIFF
--- a/gitpod-setup/laravel.yml
+++ b/gitpod-setup/laravel.yml
@@ -10,6 +10,7 @@ tasks:
       ddev composer install
       ddev npm install
       ddev artisan key:generate
+      ddev artisan migrate
     command: |
       # Upgrade DDEV to current stable version
       sudo apt update >/dev/null 2>&1 && sudo apt -qq -y install ddev


### PR DESCRIPTION
## Issue

When run with a "laravel" project type, an error is displayed when the browser attempts to access the default Welcome page:

![image](https://github.com/user-attachments/assets/b65a0ae0-1a29-4bca-aa20-49c93b8f563d)

```
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.sessions' doesn't exist
```

## Solution

This PR runs Laravel migrations. These configure the database by setting up the required columns and tables.

## Test

1. Create a Laravel project following the quickstart guide.
1. Add this addon via the PR.
1. Open the repo in Gitpod.