### PR TITLE
allow for "drupal" alias project type, fixes #17

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -14,7 +14,11 @@ post_install_actions:
     if grep -q '#ddev-generated' ${DDEV_APPROOT}/.gitpod.yml; then
       PROJECT_TASKS="$DDEV_PROJECT_TYPE.yml"
       if test -f ${DDEV_APPROOT}/.ddev/gitpod-setup/${PROJECT_TASKS}; then
+        echo "Adding $DDEV_PROJECT_TYPE specific settings"
         cat ${DDEV_APPROOT}/.ddev/gitpod-setup/${PROJECT_TASKS} > ${DDEV_APPROOT}/.gitpod.yml
+      elif [[ "$DDEV_PROJECT_TYPE" =~ "drupal" ]] && [ -f "${DDEV_APPROOT}/.ddev/gitpod-setup/drupal.yml" ]; then
+        echo "Adding Drupal specific settings"
+        cat ${DDEV_APPROOT}/.ddev/gitpod-setup/drupal.yml > ${DDEV_APPROOT}/.gitpod.yml
       fi
       cat ${DDEV_APPROOT}/.ddev/gitpod-setup/.gitpod.yml >> ${DDEV_APPROOT}/.gitpod.yml
     fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -91,3 +91,15 @@ teardown() {
   health_checks
   grep -q 'ddev drush si -y' "${TESTDIR}/.gitpod.yml"
 }
+
+@test "it configures gitpod for older Drupal versions" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  # Specify an older Drupal type
+  ddev config --project-type=drupal9
+  ddev add-on get ${DIR}
+
+  health_checks
+  grep -q 'ddev drush si -y' "${TESTDIR}/.gitpod.yml"
+}


### PR DESCRIPTION
## Issue

This PR fixes an issue that was introduced by https://github.com/ddev/ddev/issues/6635.

`drupal` project type is an alias for current version of Drupal, set as `drupal11` in the above PR.

This addons can't find a `drupal11.yml` file and therefore fails to add Drupal specific settings.

## Solution

This PR fixes the issue.

When this addon is used with the `drupal`,

- attempt to find a `drupal11.yml` file,
- else if the project type contains `drupal`, fallback to a generic `drupal.yml`.

This approach should work for future alias changes too.

This PR adds an additional test that confirms an old Drupal project type (`9`) also functions.
